### PR TITLE
Fix bug copying features from tf-idf vector

### DIFF
--- a/auto_ml/utils.py
+++ b/auto_ml/utils.py
@@ -277,7 +277,7 @@ class BasicDataCleaning(BaseEstimator, TransformerMixin):
                     #add keys as features and tfvector values as values into cleanrow dictionary object
                     keys = self.tfidfvec.get_feature_names()
                     tfvec = self.tfidfvec.transform([val]).toarray()
-                    for i in range(len(tfvec)):
+                    for i in range(len(tfvec[0])):
                         clean_row[keys[i]] = tfvec[0][i]
                 elif col_desc in self.vals_to_ignore:
                     pass


### PR DESCRIPTION
Thanks for building this! :sparkles: I'm using it to do some text classification for a project at work and came across a bug that I was able to fix:

`keys` is a list of the form `['account', 'advisor', ..., 'whistle']`. `tfvec` is a list of the form `[[0., 0., ..., 0.]]`. This code combines these two lists into `clean_row`, a dict of the form `{ 'account': 0., 'advisor': 0., ..., 'whistle': 0. }`. Previously, `len(tfvec)` was being used in the range. Since `tfvec` is a list of length 1, it was only copying the first feature, with the result being `{ 'account': 0. }`. This change uses `len(tfvec[0])` in the range so that all features are copied.