### PR TITLE
basic compatibility for keras 2

### DIFF
--- a/auto_ml/utils_models.py
+++ b/auto_ml/utils_models.py
@@ -536,5 +536,5 @@ def make_deep_learning_classifier(hidden_layers=None, num_cols=None, optimizer='
         model.add(Dense(layer_size, init='normal', activation='relu'))
 
     model.add(Dense(1, init='normal', activation=final_activation))
-    model.compile(loss='binary_crossentropy', optimizer=optimizer, metrics=['accuracy', 'poisson', 'precision', 'recall', 'fbeta_score'])
+    model.compile(loss='binary_crossentropy', optimizer=optimizer, metrics=['accuracy', 'poisson'])
     return model


### PR DESCRIPTION
removes metrics that keras removed. 

i somewhat disagree with their design decision to raise an error for metrics they've deprecated without notice rather than raising a warning for a few releases and just not reporting on that metric, but i understand optimizing for iteration speed. 