### PR TITLE
Keras 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Available options are
 - `XGBClassifier` and `XGBRegressor`
 - `LGBMClassifer` and `LGBMRegressor`
 
-These projects all have prediction time in the 1 millisecond range for a single prediction, and are able to be serialized to disk and loaded into a new environment after training.
+All of these projects are ready for production. These projects all have prediction time in the 1 millisecond range for a single prediction, and are able to be serialized to disk and loaded into a new environment after training.
 
-Depending on your machine, they can occasionally be difficult to install, so they are not included in auto_ml's default installation. You are responsible for installing them yourself.
+Depending on your machine, they can occasionally be difficult to install, so they are not included in auto_ml's default installation. You are responsible for installing them yourself. auto_ml will run fine without them installed (we check what's isntalled before choosing which algorithm to use). If you want to try the easy install, just `pip install -r advanced_requirements.txt`, which will install TensorFlow, Keras, and XGBoost. LightGBM is not available as a pip install currently.
 
 
 ## Classification

--- a/advanced_requirements.txt
+++ b/advanced_requirements.txt
@@ -1,0 +1,6 @@
+tensorflow
+keras
+xgboost
+yaml
+h5py
+tables


### PR DESCRIPTION
adds advanced_requirements.txt, and clarifies that auto_ml will run without these installed. 