### PR TITLE
Fix multimodel python 3 issue and update dependencies

### DIFF
--- a/auto_ml/predictor.py
+++ b/auto_ml/predictor.py
@@ -4,6 +4,7 @@ import math
 import multiprocessing
 import os
 import random
+from six import get_method_self, get_method_function
 import sys
 import types
 import warnings
@@ -46,10 +47,10 @@ from evolutionary_search import EvolutionaryAlgorithmSearchCV
 
 # For handling parallelism edge cases
 def _pickle_method(m):
-    if m.im_self is None:
-        return getattr, (m.im_class, m.im_func.func_name)
+    if get_method_self(m) is None:
+        return getattr, (get_method_self(m), get_method_function(m).__name__)
     else:
-        return getattr, (m.im_self, m.im_func.func_name)
+        return getattr, (get_method_self(m), get_method_function(m).__name__)
 
 try:
     import copy_reg

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ scikit-learn>=0.18.1, <1.0
 scipy>=0.14.0, <2.0
 sklearn-deap2>=0.2.1, <0.3
 tabulate>=0.7.5, <1.0
+six>=1.11.0

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         'scipy>=0.14.0, <2.0',
         'sklearn-deap2>=0.2.1, <0.3',
         'tabulate>=0.7.5, <1.0',
+        'six>=1.11.0',
     ],
 
     test_suite='nose.collector',


### PR DESCRIPTION
auto_ml would crash when using python3 due to changed class names. This resolves issue #393 using the six package. Dependencies were updated to reflect that.
