### PR TITLE
fixed bug #417

### DIFF
--- a/auto_ml/predictor.py
+++ b/auto_ml/predictor.py
@@ -59,6 +59,11 @@ except:
     copyreg.pickle(types.MethodType, _pickle_method)
 
 
+class ExtendedEvolutionaryAlgorithmSearchCV(EvolutionaryAlgorithmSearchCV):
+    def _run_search(cls):
+        """required method on base class but not implemented; it causes a TypeError"""
+        pass
+
 class Predictor(object):
 
 
@@ -1131,7 +1136,7 @@ class Predictor(object):
             fit_evolutionary_search = True
         # For some reason, EASCV doesn't play nicely with CatBoost. It blows up the memory hugely, and takes forever to train
         if fit_evolutionary_search == True:
-            gs = EvolutionaryAlgorithmSearchCV(
+            gs = ExtendedEvolutionaryAlgorithmSearchCV(
                 # Fit on the pipeline.
                 ppl,
                 # Two splits of cross-validation, by default


### PR DESCRIPTION
So `evolutionary_search`  library did not pass their test cases. 

On `cv.EvolutionaryAlgorithmSearchCV` class, it extends `sklearn.model_selection._search.BaseSearchCV` which requires `_run_search` method to be implemented. This method is not implemented on the library and therefore, it threw the error 

```
TypeError: Can't instantiate abstract class EvolutionaryAlgorithmSearchCV with abstract methods _run_search
```

According to the implementation here at [sklearn_deep](https://github.com/rsteca/sklearn-deap), the method was ignored.

Therefore, I created a class that inherits `EvolutionaryAlgorithmSearchCV` and ignored that method. 