### PR TITLE
Update DataFrameVectorizer.py

### DIFF
--- a/auto_ml/DataFrameVectorizer.py
+++ b/auto_ml/DataFrameVectorizer.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import scipy.sparse as sp
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.externals import six
+##from sklearn.externals import six
 
 from auto_ml.utils import CustomLabelEncoder
 


### PR DESCRIPTION
DeprecationWarning: The module is deprecated in version 0.21 and removed in version 0.23. This module was removed in the latest scikit-learn version. please remove this module.